### PR TITLE
pin version for cargo fuzz to 0.10.0

### DIFF
--- a/cargo-fuzz/Dockerfile
+++ b/cargo-fuzz/Dockerfile
@@ -2,7 +2,7 @@ FROM rust:1.44-buster
 
 RUN rustup update nightly-2021-08-29 && \
     rustup default nightly-2021-08-29 && \
-    cargo install cargo-fuzz
+    cargo install cargo-fuzz --version 0.10.0
  
 LABEL LANGUAGES "rust"
 LABEL FUZZERCLASS "libfuzzer"


### PR DESCRIPTION
cargo fuzz updated their version which broke fuzzing for our downstream fuzzme targets. Therefore, pinning the version to the previously working `0.10.0`